### PR TITLE
Remove versioning to make all templates expose the same ping api route

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,18 +15,16 @@ func main() {
 }
 ```
 
-All routes are grouped and versioned by number (for example: `baseUrl/v1` where `v1` is the api version). See Gin's [docs](https://github.com/gin-gonic/gin#grouping-routes) on grouping routes.
-
 This template exposes a single `/ping` route:
 ```go
 var routes = Routes{
-	Route{http.MethodGet, "/ping", PingPong},
+	Route{http.MethodGet, "/ping", Ping},
 }
 ```
 
 This path accepts a query string, and responds with the query string and current time. For example:
 ```bash
-$ curl --request GET 'localhost:3000/v1/ping?ping=hello'
+$ curl --request GET 'localhost:3000/ping?ping=hello'
 {"ping":"hello","received_at":"XXXX-XX-XX XX:XX:XX.XXXXXXXXX +0000 UTC"}
 ```
 

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -17,21 +17,20 @@ func Render(c *gin.Context, indent bool, obj interface{}) {
 }
 
 // Handles GET requests for /ping path.
-// Accepts a 'ping' query string parameter.
-// If no query string param is provided,
-// it responds with a default string.
-// Otherwise, it responds with the query
-// ping param and current timestamp.
-func PingPong(c *gin.Context) {
-	type Response struct {
+// Accepts a 'ping' query string param.
+// Responds with query string and 
+// current time (or default string and
+// current time).
+func Ping(c *gin.Context) {
+	type Pong struct {
 		Ping       string `json:"ping"`
 		ReceivedAt string `json:"received_at"`
 	}
 
-	var response Response
+	var pong Pong
 
-	response.Ping = c.DefaultQuery("ping", "To ping, or not to ping; that is the question.")
-	response.ReceivedAt = time.Now().UTC().String()
+	pong.Ping = c.DefaultQuery("ping", "To ping, or not to ping; that is the question.")
+	pong.ReceivedAt = time.Now().UTC().String()
 
-	Render(c, false, response)
+	Render(c, false, pong)
 }

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -16,5 +16,5 @@ type Route struct {
 type Routes []Route
 
 var routes = Routes{
-	Route{http.MethodGet, "/ping", PingPong},
+	Route{http.MethodGet, "/ping", Ping},
 }

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -20,16 +20,16 @@ func Init(ctx Context) {
 	// logger and recovery (crash-free) middleware
 	router := gin.Default()
 
-	// Handle versioned api routes
-	v1 := router.Group("/v1")
+	// Handle api routes
+	base := router.Group("/")
 	for _, route := range routes {
-		v1.Handle(route.Method, route.Endpoint, route.Handler)
+		base.Handle(route.Method, route.Endpoint, route.Handler)
 	}
 
 	// If no routers match request url,
 	// return 404 (Not Found)
 	router.NoRoute(NotFound)
 
-	// Listen and serve
+	// Listen and serve on 0.0.0.0:PORT
 	router.Run(":" + ctx.Port)
 }


### PR DESCRIPTION
This PR removes route versioning to make all templates expose a consistent /ping api.